### PR TITLE
Add Laravel 11 support

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -104,6 +104,10 @@ jobs:
         laravel-version:
           - ^9.51
           - ^10
+          - ^11
+        exclude:
+          - php-version: "8.1"
+            laravel-version: ^11
 
     steps:
       - uses: actions/checkout@v4
@@ -139,6 +143,10 @@ jobs:
         laravel-version:
           - ^9.51
           - ^10
+          - ^11
+        exclude:
+          - php-version: "8.1"
+            laravel-version: ^11
 
     services:
       mariadb:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ See [GitHub releases](https://github.com/mll-lab/laravel-utils/releases).
 
 ## Unreleased
 
+### Added
+
+- Support Laravel 11
+
 ## v4.10.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require": {
     "php": "^8.1",
-    "illuminate/support": "^9.51 || ^10",
+    "illuminate/support": "^9.51 || ^10 || ^11",
     "mll-lab/str_putcsv": "^1",
     "nesbot/carbon": "^2.64",
     "ramsey/uuid": "^4.7",
@@ -32,16 +32,16 @@
     "jangregor/phpstan-prophecy": "^1",
     "jbzoo/mermaid-php": "^2.3",
     "larastan/larastan": "^2",
-    "laravel/framework": "^9 || ^10",
+    "laravel/framework": "^9 || ^10 || ^11",
     "mll-lab/graphql-php-scalars": "^4 || ^5",
     "mll-lab/php-cs-fixer-config": "^5",
     "mll-lab/rector-config": "^2",
-    "orchestra/testbench": "^7.7 || ^8",
+    "orchestra/testbench": "^7.7 || ^8 || ^9",
     "phpstan/extension-installer": "^1",
     "phpstan/phpstan-deprecation-rules": "^1",
     "phpstan/phpstan-phpunit": "^1",
     "phpstan/phpstan-strict-rules": "^1",
-    "phpunit/phpunit": "^9 || ^10",
+    "phpunit/phpunit": "^9 || ^10 || ^11",
     "thecodingmachine/phpstan-safe-rule": "^1.2"
   },
   "suggest": {


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Updated dependencies to support Laravel 11. Added exclusion for PHP 8.1 and Laravel ^11, as the minimum supported PHP version is 8.2

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
