### PR TITLE
Throw `DuplicateTransitionException` on duplicate state transitions in `StateConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ See [GitHub releases](https://github.com/mll-lab/laravel-utils/releases).
 
 ## Unreleased
 
+## v8.0.0
+
+### Changed
+
+- Throw `DuplicateTransitionException` on duplicate state transitions in `StateConfig`
+
 ## v7.0.0
 
 ### Added

--- a/src/ModelStates/Exceptions/DuplicateTransitionException.php
+++ b/src/ModelStates/Exceptions/DuplicateTransitionException.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace MLL\LaravelUtils\ModelStates\Exceptions;
+
+final class DuplicateTransitionException extends \Exception
+{
+    public function __construct(string $from, string $to)
+    {
+        parent::__construct("There is already a transition from {$from} to {$to}.");
+    }
+}

--- a/src/ModelStates/StateEnumType.php
+++ b/src/ModelStates/StateEnumType.php
@@ -20,7 +20,7 @@ final class StateEnumType extends EnumType
      */
     public function __construct(string $stateClass, ?string $name = null)
     {
-        // @phpstan-ignore-next-line php-stan is not right here
+        // @phpstan-ignore-next-line PHPStan is not right here
         if (! is_subclass_of($stateClass, State::class)) {
             $abstractState = State::class;
             throw new \InvalidArgumentException("Must pass an instance of {$abstractState}, got {$stateClass}.");

--- a/tests/ModelStates/StateTest.php
+++ b/tests/ModelStates/StateTest.php
@@ -16,10 +16,12 @@ use App\ModelStates\Transitions\CustomInvalidTransition;
 use App\ModelStates\Transitions\CustomTransition;
 use Illuminate\Support\Collection as SupportCollection;
 use MLL\LaravelUtils\ModelStates\DefaultTransition;
+use MLL\LaravelUtils\ModelStates\Exceptions\DuplicateTransitionException;
 use MLL\LaravelUtils\ModelStates\Exceptions\TransitionNotAllowed;
 use MLL\LaravelUtils\ModelStates\Exceptions\TransitionNotFound;
 use MLL\LaravelUtils\ModelStates\Exceptions\UnknownStateException;
 use MLL\LaravelUtils\ModelStates\MermaidStateConfigValidator;
+use MLL\LaravelUtils\ModelStates\StateConfig;
 use MLL\LaravelUtils\ModelStates\TransitionDirection;
 use MLL\LaravelUtils\Tests\DBTestCase;
 
@@ -180,6 +182,15 @@ final class StateTest extends DBTestCase
         $this->expectException(UnknownStateException::class);
         // @phpstan-ignore-next-line only meant to trigger an error
         $model->state;
+    }
+
+    public function testDuplicateTransitionException(): void
+    {
+        $stateConfig = new StateConfig();
+        $stateConfig->allowTransition(StateA::class, StateB::class);
+
+        $this->expectExceptionObject(new DuplicateTransitionException(StateA::class, StateB::class));
+        $stateConfig->allowTransition(StateA::class, StateB::class);
     }
 
     public function testGenerateMermaidGraph(): void


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

**Breaking changes**

Instead of silently overwriting, there will now be an error on duplicate state transitions.
This prevents unexpected results when overlooking duplicate definitions.
