### PR TITLE
respect-can-transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ See [GitHub releases](https://github.com/mll-lab/laravel-utils/releases).
 
 ## Unreleased
 
+### Changed
+
+- Respect `Transition::canTransition()` in `IsStateManager::$canTransitionTo` https://github.com/mll-lab/laravel-utils/pull/38
+
 ## v10.7.0
 
 ### Added

--- a/app/ModelStates/ModelStates/ModelState.php
+++ b/app/ModelStates/ModelStates/ModelState.php
@@ -3,6 +3,7 @@
 namespace App\ModelStates\ModelStates;
 
 use App\ModelStates\StateManager;
+use App\ModelStates\Transitions\CustomInvalidTransition;
 use MLL\LaravelUtils\ModelStates\State;
 use MLL\LaravelUtils\ModelStates\StateConfig;
 
@@ -13,7 +14,9 @@ abstract class ModelState extends State
         return (new StateConfig())
             ->allowTransition(StateA::class, StateB::class)
             ->allowTransition([StateA::class, StateB::class], StateC::class)
-            ->allowTransition(StateA::class, StateD::class);
+            ->allowTransition(StateA::class, StateD::class)
+            ->allowTransition(StateC::class, StateA::class)
+            ->allowTransition(StateD::class, StateA::class, CustomInvalidTransition::class);
     }
 
     public static function defaultState(): ModelState

--- a/src/ModelStates/IsStateManager.php
+++ b/src/ModelStates/IsStateManager.php
@@ -28,8 +28,13 @@ trait IsStateManager
         $state = $stateable->state;
         assert($state instanceof State);
 
+        $stateMachine = $stateable->stateMachine();
+
         return $stateable->stateClass()::config()
-            ->possibleNextStates($state);
+            ->possibleNextStates($state)
+            ->filter(fn (State $nextState): bool => $stateMachine
+                ->instantiateTransitionClass($state::class, $nextState::class)
+                ->canTransition());
     }
 
     /** @return Collection<array-key, Transition> */

--- a/tests/ModelStates/StateTest.php
+++ b/tests/ModelStates/StateTest.php
@@ -119,7 +119,19 @@ final class StateTest extends DBTestCase
         ]), $model->stateManager->canTransitionTo);
 
         $model->state = new StateB();
-        self::assertEquals(new SupportCollection([StateC::class => new StateC()]), $model->stateManager->canTransitionTo);
+        self::assertEquals(new SupportCollection([
+            StateC::class => new StateC(),
+        ]), $model->stateManager->canTransitionTo);
+
+        $model->state = new StateC();
+        self::assertEquals(new SupportCollection([
+            StateA::class => new StateA(),
+        ]), $model->stateManager->canTransitionTo);
+
+        $model->state = new StateA();
+        $model->state = new StateD();
+        self::assertEquals(new SupportCollection([
+        ]), $model->stateManager->canTransitionTo);
     }
 
     public function testReturnsListOfPossibleNextTransitionsForCustomTransition(): void
@@ -206,6 +218,8 @@ graph TB;
     STATE_A-->FOO_BAR;
     STATE_A-->STATE_C;
     STATE_A-->STATE_D;
+    STATE_C-->STATE_A;
+    STATE_D-->|"CustomInvalidTransition"|STATE_A;
 
 linkStyle default interpolate basis;
 MERMAID;


### PR DESCRIPTION
- [x] Added automated tests
- [ ] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Respect `Transition::canTransition()` in `IsStateManager::$canTransitionTo`

**Breaking changes**

none
