### PR TITLE
feat: forbid string-keyed collection operations via PHPStan rules

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -53,6 +53,44 @@ parameters:
   - method: 'Illuminate\Support\Collection::pluck()'
     message: 'because it is not type safe.'
     errorTip: 'Use map() instead.'
+  - method: 'Illuminate\Support\Collection::keyBy()'
+    message: 'because string keys are not type safe.'
+    errorTip: 'Use a closure instead: ->keyBy(fn (Model $item): string => $item->attribute)'
+    allowParamsAnywhere:
+    - position: 1
+      name: 'keyBy'
+      typeString: 'Closure'
+  - method: 'Illuminate\Support\Collection::sortBy()'
+    message: 'because string keys are not type safe.'
+    errorTip: 'Use a closure instead: ->sortBy(fn (Model $item): string => $item->attribute)'
+    allowParamsAnywhere:
+    - position: 1
+      name: 'callback'
+      typeString: 'Closure'
+  - method: 'Illuminate\Support\Collection::sortByDesc()'
+    message: 'because string keys are not type safe.'
+    errorTip: 'Use a closure instead: ->sortByDesc(fn (Model $item): string => $item->attribute)'
+    allowParamsAnywhere:
+    - position: 1
+      name: 'callback'
+      typeString: 'Closure'
+  - method: 'Illuminate\Support\Collection::groupBy()'
+    message: 'because string keys are not type safe.'
+    errorTip: 'Use a closure instead: ->groupBy(fn (Model $item): string => $item->attribute)'
+    allowParamsAnywhere:
+    - position: 1
+      name: 'groupBy'
+      typeString: 'Closure'
+  - method: 'Illuminate\Support\Collection::firstWhere()'
+    message: 'because string keys are not type safe.'
+    errorTip: 'Use first() with a closure instead: ->first(fn (Model $item): bool => $item->attribute === $value)'
+  - method: 'Illuminate\Support\Collection::get()'
+    message: 'because string keys are not type safe.'
+    errorTip: 'Use find() for models, or access the underlying array.'
+    allowExceptParams:
+    - position: 1
+      name: 'key'
+      typeString: 'string'
   - method: 'Illuminate\Testing\TestResponse::dump()'
     message: 'it is used for debugging.'
     errorTip: 'Remove debugging code before committing.'

--- a/rules.neon
+++ b/rules.neon
@@ -84,13 +84,6 @@ parameters:
   - method: 'Illuminate\Support\Collection::firstWhere()'
     message: 'because string keys are not type safe.'
     errorTip: 'Use first() with a closure instead: ->first(fn (Model $item): bool => $item->attribute === $value)'
-  - method: 'Illuminate\Support\Collection::get()'
-    message: 'because string keys are not type safe.'
-    errorTip: 'Use find() for models, or access the underlying array.'
-    allowExceptParams:
-    - position: 1
-      name: 'key'
-      typeString: 'string'
   - method: 'Illuminate\Testing\TestResponse::dump()'
     message: 'it is used for debugging.'
     errorTip: 'Remove debugging code before committing.'

--- a/rules.neon
+++ b/rules.neon
@@ -53,34 +53,37 @@ parameters:
   - method: 'Illuminate\Support\Collection::pluck()'
     message: 'because it is not type safe.'
     errorTip: 'Use Collection::map() instead, or shorten Builder::get()->pluck() to Builder::pluck().'
+  - method: 'Illuminate\Database\Eloquent\Collection::pluck()'
+    message: 'because it is not type safe.'
+    errorTip: 'Use Collection::map() instead, or shorten Builder::get()->pluck() to Builder::pluck().'
   - method: 'Illuminate\Support\Collection::keyBy()'
     message: 'because string keys are not type safe.'
     errorTip: 'Use a closure instead: ->keyBy(fn (Model $item): string => $item->attribute)'
-    allowParamsAnywhere:
+    allowExceptParams:
     - position: 1
       name: 'keyBy'
-      typeString: 'Closure'
+      typeString: 'string'
   - method: 'Illuminate\Support\Collection::sortBy()'
     message: 'because string keys are not type safe.'
     errorTip: 'Use a closure instead: ->sortBy(fn (Model $item): string => $item->attribute)'
-    allowParamsAnywhere:
+    allowExceptParams:
     - position: 1
       name: 'callback'
-      typeString: 'Closure'
+      typeString: 'string'
   - method: 'Illuminate\Support\Collection::sortByDesc()'
     message: 'because string keys are not type safe.'
     errorTip: 'Use a closure instead: ->sortByDesc(fn (Model $item): string => $item->attribute)'
-    allowParamsAnywhere:
+    allowExceptParams:
     - position: 1
       name: 'callback'
-      typeString: 'Closure'
+      typeString: 'string'
   - method: 'Illuminate\Support\Collection::groupBy()'
     message: 'because string keys are not type safe.'
     errorTip: 'Use a closure instead: ->groupBy(fn (Model $item): string => $item->attribute)'
-    allowParamsAnywhere:
+    allowExceptParams:
     - position: 1
       name: 'groupBy'
-      typeString: 'Closure'
+      typeString: 'string'
   - method: 'Illuminate\Support\Collection::firstWhere()'
     message: 'because string keys are not type safe.'
     errorTip: 'Use first() with a closure instead: ->first(fn (Model $item): bool => $item->attribute === $value)'

--- a/rules.neon
+++ b/rules.neon
@@ -52,7 +52,7 @@ parameters:
     errorTip: 'Use filter()/reject() instead.'
   - method: 'Illuminate\Support\Collection::pluck()'
     message: 'because it is not type safe.'
-    errorTip: 'Use map() instead.'
+    errorTip: 'Use Collection::map() instead, or shorten Builder::get()->pluck() to Builder::pluck().'
   - method: 'Illuminate\Support\Collection::keyBy()'
     message: 'because string keys are not type safe.'
     errorTip: 'Use a closure instead: ->keyBy(fn (Model $item): string => $item->attribute)'

--- a/tests/PHPStan/PHPStanExtensionTest.php
+++ b/tests/PHPStan/PHPStanExtensionTest.php
@@ -8,7 +8,9 @@ use PHPStan\File\FileHelper;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-/** Built like https://github.com/larastan/larastan/blob/e01fd6ad60c659b735816c21a14df0a3cbca7dbe/tests/Integration/IntegrationTest.php. */
+/**
+ * Built like https://github.com/larastan/larastan/blob/e01fd6ad60c659b735816c21a14df0a3cbca7dbe/tests/Integration/IntegrationTest.php.
+ */
 final class PHPStanExtensionTest extends PHPStanTestCase
 {
     /** @return iterable<array{0: string, 1?: array<int, array<int, string>>}> */
@@ -34,6 +36,15 @@ final class PHPStanExtensionTest extends PHPStanTestCase
         yield [__DIR__ . '/data/model.php', [
             6 => ['Calling Illuminate\Database\Eloquent\Model::update() (as App\Models\User::update()) is forbidden, it assigns attributes through an array and is not type safe, without parameters it is like save().'],
             7 => ['Calling Illuminate\Database\Eloquent\Model::update() (as App\Models\User::update()) is forbidden, it assigns attributes through an array and is not type safe, without parameters it is like save().'],
+        ]];
+
+        yield [__DIR__ . '/data/collection.php', [
+            10 => ['Calling Illuminate\Support\Collection::keyBy() is forbidden, because string keys are not type safe.'],
+            11 => ['Calling Illuminate\Support\Collection::sortBy() is forbidden, because string keys are not type safe.'],
+            12 => ['Calling Illuminate\Support\Collection::sortByDesc() is forbidden, because string keys are not type safe.'],
+            13 => ['Calling Illuminate\Support\Collection::groupBy() is forbidden, because string keys are not type safe.'],
+            14 => ['Calling Illuminate\Support\Collection::firstWhere() is forbidden, because string keys are not type safe.'],
+            15 => ['Calling Illuminate\Support\Collection::get() is forbidden, because string keys are not type safe.'],
         ]];
     }
 

--- a/tests/PHPStan/PHPStanExtensionTest.php
+++ b/tests/PHPStan/PHPStanExtensionTest.php
@@ -39,12 +39,11 @@ final class PHPStanExtensionTest extends PHPStanTestCase
         ]];
 
         yield [__DIR__ . '/data/collection.php', [
-            10 => ['Calling Illuminate\Support\Collection::keyBy() is forbidden, because string keys are not type safe.'],
-            11 => ['Calling Illuminate\Support\Collection::sortBy() is forbidden, because string keys are not type safe.'],
-            12 => ['Calling Illuminate\Support\Collection::sortByDesc() is forbidden, because string keys are not type safe.'],
-            13 => ['Calling Illuminate\Support\Collection::groupBy() is forbidden, because string keys are not type safe.'],
-            14 => ['Calling Illuminate\Support\Collection::firstWhere() is forbidden, because string keys are not type safe.'],
-            15 => ['Calling Illuminate\Support\Collection::get() is forbidden, because string keys are not type safe.'],
+            9 => ['Calling Illuminate\Support\Collection::keyBy() is forbidden, because string keys are not type safe.'],
+            10 => ['Calling Illuminate\Support\Collection::sortBy() is forbidden, because string keys are not type safe.'],
+            11 => ['Calling Illuminate\Support\Collection::sortByDesc() is forbidden, because string keys are not type safe.'],
+            12 => ['Calling Illuminate\Support\Collection::groupBy() is forbidden, because string keys are not type safe.'],
+            13 => ['Calling Illuminate\Support\Collection::firstWhere() is forbidden, because string keys are not type safe.'],
         ]];
     }
 

--- a/tests/PHPStan/PHPStanExtensionTest.php
+++ b/tests/PHPStan/PHPStanExtensionTest.php
@@ -39,11 +39,18 @@ final class PHPStanExtensionTest extends PHPStanTestCase
         ]];
 
         yield [__DIR__ . '/data/collection.php', [
-            9 => ['Calling Illuminate\Support\Collection::keyBy() is forbidden, because string keys are not type safe.'],
-            10 => ['Calling Illuminate\Support\Collection::sortBy() is forbidden, because string keys are not type safe.'],
-            11 => ['Calling Illuminate\Support\Collection::sortByDesc() is forbidden, because string keys are not type safe.'],
-            12 => ['Calling Illuminate\Support\Collection::groupBy() is forbidden, because string keys are not type safe.'],
-            13 => ['Calling Illuminate\Support\Collection::firstWhere() is forbidden, because string keys are not type safe.'],
+            11 => ['Calling Illuminate\Support\Collection::keyBy() is forbidden, because string keys are not type safe.'],
+            12 => ['Calling Illuminate\Support\Collection::sortBy() is forbidden, because string keys are not type safe.'],
+            13 => ['Calling Illuminate\Support\Collection::sortByDesc() is forbidden, because string keys are not type safe.'],
+            14 => ['Calling Illuminate\Support\Collection::groupBy() is forbidden, because string keys are not type safe.'],
+            15 => ['Calling Illuminate\Support\Collection::firstWhere() is forbidden, because string keys are not type safe.'],
+            16 => ['Calling Illuminate\Support\Collection::pluck() is forbidden, because it is not type safe.'],
+            19 => ['Calling Illuminate\Support\Collection::keyBy() (as Illuminate\Database\Eloquent\Collection::keyBy()) is forbidden, because string keys are not type safe.'],
+            20 => ['Calling Illuminate\Support\Collection::sortBy() (as Illuminate\Database\Eloquent\Collection::sortBy()) is forbidden, because string keys are not type safe.'],
+            21 => ['Calling Illuminate\Support\Collection::sortByDesc() (as Illuminate\Database\Eloquent\Collection::sortByDesc()) is forbidden, because string keys are not type safe.'],
+            22 => ['Calling Illuminate\Support\Collection::groupBy() (as Illuminate\Database\Eloquent\Collection::groupBy()) is forbidden, because string keys are not type safe.'],
+            23 => ['Calling Illuminate\Support\Collection::firstWhere() (as Illuminate\Database\Eloquent\Collection::firstWhere()) is forbidden, because string keys are not type safe.'],
+            24 => ['Calling Illuminate\Database\Eloquent\Collection::pluck() is forbidden, because it is not type safe.'],
         ]];
     }
 

--- a/tests/PHPStan/data/collection.php
+++ b/tests/PHPStan/data/collection.php
@@ -4,7 +4,6 @@ use App\Models\User;
 use Illuminate\Support\Collection;
 
 /** @var Collection<int, User> $collection */
-/** @var Collection<string, User> $stringKeyedCollection */
 
 // Disallowed: string keys
 $collection->keyBy('name');
@@ -12,7 +11,6 @@ $collection->sortBy('name');
 $collection->sortByDesc('name');
 $collection->groupBy('name');
 $collection->firstWhere('name', 'John');
-$stringKeyedCollection->get('some_key');
 
 // Allowed: closures
 $collection->keyBy(fn (User $user): int => $user->getKey());
@@ -20,4 +18,3 @@ $collection->sortBy(fn (User $user): int => $user->getKey());
 $collection->sortByDesc(fn (User $user): int => $user->getKey());
 $collection->groupBy(fn (User $user): int => $user->getKey());
 $collection->first(fn (User $user): bool => $user->getKey() === 1);
-$collection->get(0);

--- a/tests/PHPStan/data/collection.php
+++ b/tests/PHPStan/data/collection.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+/** @var Collection<int, User> $collection */
+/** @var Collection<string, User> $stringKeyedCollection */
+
+// Disallowed: string keys
+$collection->keyBy('name');
+$collection->sortBy('name');
+$collection->sortByDesc('name');
+$collection->groupBy('name');
+$collection->firstWhere('name', 'John');
+$stringKeyedCollection->get('some_key');
+
+// Allowed: closures
+$collection->keyBy(fn (User $user): int => $user->getKey());
+$collection->sortBy(fn (User $user): int => $user->getKey());
+$collection->sortByDesc(fn (User $user): int => $user->getKey());
+$collection->groupBy(fn (User $user): int => $user->getKey());
+$collection->first(fn (User $user): bool => $user->getKey() === 1);
+$collection->get(0);

--- a/tests/PHPStan/data/collection.php
+++ b/tests/PHPStan/data/collection.php
@@ -1,20 +1,44 @@
 <?php declare(strict_types=1);
 
 use App\Models\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 
 /** @var Collection<int, User> $collection */
+/** @var EloquentCollection<int, User> $eloquentCollection */
 
-// Disallowed: string keys
+// Disallowed: Support\Collection with string keys
 $collection->keyBy('name');
 $collection->sortBy('name');
 $collection->sortByDesc('name');
 $collection->groupBy('name');
 $collection->firstWhere('name', 'John');
+$collection->pluck('name');
 
-// Allowed: closures
+// Disallowed: Eloquent\Collection with string keys
+$eloquentCollection->keyBy('name');
+$eloquentCollection->sortBy('name');
+$eloquentCollection->sortByDesc('name');
+$eloquentCollection->groupBy('name');
+$eloquentCollection->firstWhere('name', 'John');
+$eloquentCollection->pluck('name');
+
+// Allowed: Support\Collection with closures
 $collection->keyBy(fn (User $user): int => $user->getKey());
 $collection->sortBy(fn (User $user): int => $user->getKey());
 $collection->sortByDesc(fn (User $user): int => $user->getKey());
 $collection->groupBy(fn (User $user): int => $user->getKey());
 $collection->first(fn (User $user): bool => $user->getKey() === 1);
+
+// Allowed: sortBy/sortByDesc with arrays (multi-key sorting)
+$collection->sortBy([fn (User $userA, User $userB): int => $userA->getKey() <=> $userB->getKey()]);
+$collection->sortByDesc([fn (User $userA, User $userB): int => $userA->getKey() <=> $userB->getKey()]);
+$eloquentCollection->sortBy([fn (User $userA, User $userB): int => $userA->getKey() <=> $userB->getKey()]);
+$eloquentCollection->sortByDesc([fn (User $userA, User $userB): int => $userA->getKey() <=> $userB->getKey()]);
+
+// Allowed: Eloquent\Collection with closures
+$eloquentCollection->keyBy(fn (User $user): int => $user->getKey());
+$eloquentCollection->sortBy(fn (User $user): int => $user->getKey());
+$eloquentCollection->sortByDesc(fn (User $user): int => $user->getKey());
+$eloquentCollection->groupBy(fn (User $user): int => $user->getKey());
+$eloquentCollection->first(fn (User $user): bool => $user->getKey() === 1);


### PR DESCRIPTION
Ban `keyBy()`, `sortBy()`, `sortByDesc()`, `groupBy()` with string arguments on `Collection` and `EloquentCollection` — closures are still allowed since PHPStan can verify type-safe access.

Ban `firstWhere()` entirely — use `first()` with a closure instead.

Also improves the `pluck()` error tip and extends the ban to `EloquentCollection::pluck()`.