### PR TITLE
feat: allow php-utils v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": "^8.2",
     "illuminate/support": "^11 || ^12",
-    "mll-lab/php-utils": "^5.2",
+    "mll-lab/php-utils": "^5.2 || ^6",
     "mll-lab/str_putcsv": "^1",
     "ramsey/uuid": "^4.7",
     "thecodingmachine/safe": "^1 || ^2 || ^3"


### PR DESCRIPTION
## Summary

- Widen `mll-lab/php-utils` constraint from `^5.2` to `^5.2 || ^6`

## Why

php-utils v6.0.0 was released with breaking changes in the IlluminaSampleSheet V2 API. laravel-utils doesn't use any of the affected classes, so this is safe to widen.

Needed to unblock `composer update mll-lab/php-utils mll-lab/laravel-utils` in downstream projects.