### PR TITLE
feat: add command to refresh stale queue job timeouts

### DIFF
--- a/app/Jobs/TimeoutJob.php
+++ b/app/Jobs/TimeoutJob.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+final class TimeoutJob implements ShouldQueue
+{
+    use InteractsWithQueue;
+    use Queueable;
+
+    public int $timeout = 300;
+
+    public function handle(): void {}
+}

--- a/app/migrations/2025_01_01_000000_create_jobs_table.php
+++ b/app/migrations/2025_01_01_000000_create_jobs_table.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::create('jobs', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+    }
+};

--- a/app/migrations/2025_01_01_000001_create_failed_jobs_table.php
+++ b/app/migrations/2025_01_01_000001_create_failed_jobs_table.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::create('failed_jobs', function (Blueprint $table): void {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_jobs');
+    }
+};

--- a/src/LaravelUtilsServiceProvider.php
+++ b/src/LaravelUtilsServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use MLL\LaravelUtils\Collection\CollectionMixin;
 use MLL\LaravelUtils\Queue\DispatchJob;
+use MLL\LaravelUtils\Queue\RefreshQueueTimeouts;
 
 class LaravelUtilsServiceProvider extends ServiceProvider
 {
@@ -17,6 +18,7 @@ class LaravelUtilsServiceProvider extends ServiceProvider
 
         $this->commands([
             DispatchJob::class,
+            RefreshQueueTimeouts::class,
         ]);
 
         Collection::mixin(new CollectionMixin());

--- a/src/Queue/RefreshQueueTimeouts.php
+++ b/src/Queue/RefreshQueueTimeouts.php
@@ -24,6 +24,7 @@ class RefreshQueueTimeouts extends Command
         $failedJobsTable = config('queue.failed.table', 'failed_jobs');
         assert(is_string($failedJobsTable));
 
+        /** @var bool $isDryRun flag option, see signature */
         $isDryRun = $this->option('dry-run');
 
         /** @var list<string> $queues option may be used multiple times, see signature */

--- a/src/Queue/RefreshQueueTimeouts.php
+++ b/src/Queue/RefreshQueueTimeouts.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types=1);
+
+namespace MLL\LaravelUtils\Queue;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class RefreshQueueTimeouts extends Command
+{
+    protected $signature = '
+        laravel-utils:refresh-queue-timeouts
+        {--queue=* : Limit to specific queue(s)}
+        {--dry-run : Show what would change without modifying anything}
+    ';
+
+    protected $description = 'Refresh stale timeout values in queued and failed jobs from current class defaults';
+
+    public function handle(): void
+    {
+        $jobsTable = config('queue.connections.database.table', 'jobs');
+        assert(is_string($jobsTable));
+
+        $failedJobsTable = config('queue.failed.table', 'failed_jobs');
+        assert(is_string($failedJobsTable));
+
+        $isDryRun = $this->option('dry-run');
+
+        /** @var list<string> $queues option may be used multiple times, see signature */
+        $queues = $this->option('queue');
+
+        $timeoutsByClass = $this->resolveTimeouts($jobsTable, $failedJobsTable);
+
+        if ($timeoutsByClass === []) {
+            $this->info('No job classes with timeout properties found.');
+
+            return;
+        }
+
+        $totalUpdated = 0;
+
+        foreach ($timeoutsByClass as $className => $timeout) {
+            foreach ([$jobsTable, $failedJobsTable] as $table) {
+                $updated = $this->updateTable($table, $className, $timeout, $queues, $isDryRun);
+                if ($updated === 0) {
+                    continue;
+                }
+
+                $totalUpdated += $updated;
+
+                $action = $isDryRun
+                    ? 'Would update'
+                    : 'Updated';
+                $this->line("{$action} {$updated} job(s) in <comment>{$table}</comment> for <info>{$className}</info> to timeout {$timeout}.");
+            }
+        }
+
+        if ($totalUpdated === 0) {
+            $this->info('All jobs already have current timeout values.');
+        } elseif ($isDryRun) {
+            $this->warn("Dry run: {$totalUpdated} job(s) would be updated.");
+        } else {
+            $this->info("Updated {$totalUpdated} job(s).");
+        }
+    }
+
+    /** @return array<string, int> */
+    private function resolveTimeouts(string $jobsTable, string $failedJobsTable): array
+    {
+        $classNames = (new Collection([$jobsTable, $failedJobsTable]))
+            ->flatMap(fn (string $table): Collection => DB::table($table)
+                ->select(DB::raw("DISTINCT JSON_UNQUOTE(JSON_EXTRACT(payload, '$.displayName')) as display_name"))
+                ->pluck('display_name'))
+            ->unique()
+            ->filter();
+
+        $timeoutsByClass = [];
+
+        foreach ($classNames as $className) {
+            assert(is_string($className));
+
+            if (! class_exists($className)) {
+                $this->warn("Skipping unknown class: {$className}.");
+
+                continue;
+            }
+
+            $reflection = new \ReflectionClass($className);
+
+            if (! $reflection->hasProperty('timeout')) {
+                continue;
+            }
+
+            $property = $reflection->getProperty('timeout');
+            $defaultValue = $property->getDefaultValue();
+
+            if (! is_int($defaultValue)) {
+                continue;
+            }
+
+            $timeoutsByClass[$className] = $defaultValue;
+        }
+
+        return $timeoutsByClass;
+    }
+
+    /** @param list<string> $queues */
+    private function updateTable(string $table, string $className, int $timeout, array $queues, bool $isDryRun): int
+    {
+        $query = DB::table($table)
+            ->where(DB::raw("JSON_UNQUOTE(JSON_EXTRACT(payload, '$.displayName'))"), $className)
+            ->where(DB::raw("JSON_EXTRACT(payload, '$.timeout')"), '!=', $timeout);
+
+        if ($queues !== []) {
+            $query->whereIn('queue', $queues);
+        }
+
+        if ($isDryRun) {
+            return $query->count();
+        }
+
+        return $query->update([
+            'payload' => DB::raw("JSON_SET(payload, '$.timeout', {$timeout})"),
+        ]);
+    }
+}

--- a/tests/Queue/RefreshQueueTimeoutsTest.php
+++ b/tests/Queue/RefreshQueueTimeoutsTest.php
@@ -1,0 +1,154 @@
+<?php declare(strict_types=1);
+
+namespace MLL\LaravelUtils\Tests\Queue;
+
+use App\Jobs\TimeoutJob;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Testing\PendingCommand;
+use MLL\LaravelUtils\Tests\DBTestCase;
+
+use function Safe\json_decode;
+use function Safe\json_encode;
+
+final class RefreshQueueTimeoutsTest extends DBTestCase
+{
+    public function testUpdatesStaleTimeoutInJobs(): void
+    {
+        $this->insertJob('jobs', 'default', TimeoutJob::class, 60);
+
+        $this->runRefreshCommand();
+
+        $payload = $this->jobPayload('jobs');
+        self::assertSame(300, $payload['timeout']);
+    }
+
+    public function testUpdatesStaleTimeoutInFailedJobs(): void
+    {
+        $this->insertFailedJob('default', TimeoutJob::class, 60);
+
+        $this->runRefreshCommand();
+
+        $payload = $this->jobPayload('failed_jobs');
+        self::assertSame(300, $payload['timeout']);
+    }
+
+    public function testSkipsJobsWithCurrentTimeout(): void
+    {
+        $this->insertJob('jobs', 'default', TimeoutJob::class, 300);
+
+        $command = $this->artisan('laravel-utils:refresh-queue-timeouts');
+        self::assertInstanceOf(PendingCommand::class, $command);
+        $command
+            ->expectsOutputToContain('All jobs already have current timeout values.')
+            ->assertSuccessful();
+
+        $payload = $this->jobPayload('jobs');
+        self::assertSame(300, $payload['timeout']);
+    }
+
+    public function testDryRunDoesNotModifyPayloads(): void
+    {
+        $this->insertJob('jobs', 'default', TimeoutJob::class, 60);
+        $this->insertFailedJob('default', TimeoutJob::class, 60);
+
+        $command = $this->artisan('laravel-utils:refresh-queue-timeouts', ['--dry-run' => true]);
+        self::assertInstanceOf(PendingCommand::class, $command);
+        $command
+            ->expectsOutputToContain('Would update')
+            ->assertSuccessful();
+
+        $jobsPayload = $this->jobPayload('jobs');
+        self::assertSame(60, $jobsPayload['timeout']);
+
+        $failedPayload = $this->jobPayload('failed_jobs');
+        self::assertSame(60, $failedPayload['timeout']);
+    }
+
+    public function testQueueFilterOnlyUpdatesMatchingQueue(): void
+    {
+        $this->insertJob('jobs', 'specific', TimeoutJob::class, 60);
+        $this->insertJob('jobs', 'other', TimeoutJob::class, 60);
+
+        $this->runRefreshCommand(['--queue' => ['specific']]);
+
+        $rows = DB::table('jobs')->get();
+        self::assertCount(2, $rows);
+
+        foreach ($rows as $row) {
+            $payloadString = $row->payload;
+            self::assertIsString($payloadString);
+
+            /** @var array<string, mixed> $payload */
+            $payload = json_decode($payloadString, true);
+
+            if ($row->queue === 'specific') {
+                self::assertSame(300, $payload['timeout']);
+            } else {
+                self::assertSame(60, $payload['timeout']);
+            }
+        }
+    }
+
+    public function testSkipsUnknownClassGracefully(): void
+    {
+        $this->insertJob('jobs', 'default', 'App\\Jobs\\NonExistentJob', 60);
+
+        $command = $this->artisan('laravel-utils:refresh-queue-timeouts');
+        self::assertInstanceOf(PendingCommand::class, $command);
+        $command
+            ->expectsOutputToContain('Skipping unknown class')
+            ->assertSuccessful();
+    }
+
+    /** @param array<string, mixed> $parameters */
+    private function runRefreshCommand(array $parameters = []): void
+    {
+        $command = $this->artisan('laravel-utils:refresh-queue-timeouts', $parameters);
+        self::assertInstanceOf(PendingCommand::class, $command);
+        $command->assertSuccessful();
+    }
+
+    private function insertJob(string $table, string $queue, string $className, int $timeout): void
+    {
+        DB::table($table)->insert([
+            'queue' => $queue,
+            'payload' => json_encode([
+                'displayName' => $className,
+                'timeout' => $timeout,
+                'data' => ['command' => ''],
+            ]),
+            'attempts' => 0,
+            'available_at' => time(),
+            'created_at' => time(),
+        ]);
+    }
+
+    private function insertFailedJob(string $queue, string $className, int $timeout): void
+    {
+        DB::table('failed_jobs')->insert([
+            'uuid' => (string) Str::uuid(),
+            'connection' => 'database',
+            'queue' => $queue,
+            'payload' => json_encode([
+                'displayName' => $className,
+                'timeout' => $timeout,
+                'data' => ['command' => ''],
+            ]),
+            'exception' => 'Test exception',
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    private function jobPayload(string $table): array
+    {
+        $row = DB::table($table)->first();
+        self::assertInstanceOf(\stdClass::class, $row);
+
+        $payloadString = $row->payload;
+        self::assertIsString($payloadString);
+
+        /** @var array<string, mixed> */
+        return json_decode($payloadString, true);
+    }
+}

--- a/tests/Queue/RefreshQueueTimeoutsTest.php
+++ b/tests/Queue/RefreshQueueTimeoutsTest.php
@@ -90,6 +90,33 @@ final class RefreshQueueTimeoutsTest extends DBTestCase
         }
     }
 
+    public function testUpdatesNullTimeoutInPayload(): void
+    {
+        $this->insertJobWithPayload('jobs', 'default', json_encode([
+            'displayName' => TimeoutJob::class,
+            'timeout' => null,
+            'data' => ['command' => ''],
+        ]));
+
+        $this->runRefreshCommand();
+
+        $payload = $this->jobPayload('jobs');
+        self::assertSame(300, $payload['timeout']);
+    }
+
+    public function testSkipsJobsWithMissingTimeoutKey(): void
+    {
+        $this->insertJobWithPayload('jobs', 'default', json_encode([
+            'displayName' => TimeoutJob::class,
+            'data' => ['command' => ''],
+        ]));
+
+        $this->runRefreshCommand();
+
+        $payload = $this->jobPayload('jobs');
+        self::assertArrayNotHasKey('timeout', $payload);
+    }
+
     public function testSkipsUnknownClassGracefully(): void
     {
         $this->insertJob('jobs', 'default', 'App\\Jobs\\NonExistentJob', 60);
@@ -111,13 +138,18 @@ final class RefreshQueueTimeoutsTest extends DBTestCase
 
     private function insertJob(string $table, string $queue, string $className, int $timeout): void
     {
+        $this->insertJobWithPayload($table, $queue, json_encode([
+            'displayName' => $className,
+            'timeout' => $timeout,
+            'data' => ['command' => ''],
+        ]));
+    }
+
+    private function insertJobWithPayload(string $table, string $queue, string $payload): void
+    {
         DB::table($table)->insert([
             'queue' => $queue,
-            'payload' => json_encode([
-                'displayName' => $className,
-                'timeout' => $timeout,
-                'data' => ['command' => ''],
-            ]),
+            'payload' => $payload,
             'attempts' => 0,
             'available_at' => time(),
             'created_at' => time(),


### PR DESCRIPTION
Adds `laravel-utils:refresh-queue-timeouts` artisan command that updates stale timeout values in queued and failed jobs from current class defaults.

Uses reflection to read the `$timeout` property from job classes and compares against stored JSON payloads. Supports `--queue` filtering and `--dry-run` mode.