### PR TITLE
Add migrate:check command aware of ConditionalMigration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ See [GitHub releases](https://github.com/mll-lab/laravel-utils/releases).
 
 ## Unreleased
 
+### Added
+
+- Add `migrate:check` command that is aware of `ConditionalMigration`
+
 ## v10.10.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -95,10 +95,16 @@ migrations where `shouldRun()` returns `false` are not reported as pending.
 php artisan migrate:check
 ```
 
-Use `--path` and `--realpath` to check specific migration directories:
+Use `--path` to check specific migration directories:
 
 ```sh
-php artisan migrate:check --path=database/migrations --realpath
+php artisan migrate:check --path=database/migrations
+```
+
+Use `--realpath` when providing absolute paths:
+
+```sh
+php artisan migrate:check --path=/opt/app/database/migrations --realpath
 ```
 
 Returns exit code `0` when no migrations are pending, exit code `1` otherwise.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ return new class extends Migration implements ConditionalMigration {
 };
 ```
 
+### Migrate Check
+
+The `migrate:check` command compares migration files against the migrations table and reports
+any truly pending migrations. Unlike other implementations, it is aware of `ConditionalMigration`:
+migrations where `shouldRun()` returns `false` are not reported as pending.
+
+```sh
+php artisan migrate:check
+```
+
+Use `--path` and `--realpath` to check specific migration directories:
+
+```sh
+php artisan migrate:check --path=database/migrations --realpath
+```
+
+Returns exit code `0` when no migrations are pending, exit code `1` otherwise.
+
 ### Strict Stubs
 
 To continually keep your stubs updated with the latest and greatest from this package,

--- a/README.md
+++ b/README.md
@@ -95,16 +95,10 @@ migrations where `shouldRun()` returns `false` are not reported as pending.
 php artisan migrate:check
 ```
 
-Use `--path` to check specific migration directories:
+Use `--path` to check a specific migration directory:
 
 ```sh
-php artisan migrate:check --path=database/migrations
-```
-
-Use `--realpath` when providing absolute paths:
-
-```sh
-php artisan migrate:check --path=/opt/app/database/migrations --realpath
+php artisan migrate:check --path=vendor/mll-lab/laravel-utils/migrations
 ```
 
 Returns exit code `0` when no migrations are pending, exit code `1` otherwise.

--- a/src/Database/DatabaseServiceProvider.php
+++ b/src/Database/DatabaseServiceProvider.php
@@ -16,6 +16,8 @@ class DatabaseServiceProvider extends ServiceProvider
             $app->make('files'),
             $app->make('events'),
         ));
+
+        $this->commands([MigrateCheckCommand::class]);
     }
 
     public function boot(): void

--- a/src/Database/MigrateCheckCommand.php
+++ b/src/Database/MigrateCheckCommand.php
@@ -12,30 +12,26 @@ class MigrateCheckCommand extends BaseCommand
 
     protected $description = 'Check if there are any pending migrations';
 
-    public function __construct(
-        protected Migrator $migrator
-    ) {
-        parent::__construct();
-    }
-
     public function handle(): int
     {
+        $migrator = $this->migrator();
+
         /** @var int Callback always returns int */
-        return $this->migrator->usingConnection($this->option('database'), function (): int { // @phpstan-ignore argument.type
-            if (! $this->migrator->repositoryExists()) {
+        return $migrator->usingConnection($this->option('database'), function () use ($migrator): int { // @phpstan-ignore argument.type
+            if (! $migrator->repositoryExists()) {
                 $this->components->error('Migration table not found.');
 
                 return 1;
             }
 
-            $files = $this->migrator->getMigrationFiles($this->getMigrationPaths());
-            $ran = $this->migrator->getRepository()->getRan();
+            $files = $migrator->getMigrationFiles($this->getMigrationPaths());
+            $ran = $migrator->getRepository()->getRan();
 
-            $pendingFiles = array_diff_key($files, array_flip($ran));
+            $pendingFiles = array_diff_key($files, array_flip($ran)); // @phpstan-ignore argument.type
 
             $trulyPending = [];
             foreach ($pendingFiles as $name => $path) {
-                $migration = $this->resolveMigration($path);
+                $migration = $this->resolveMigration($migrator, $path);
 
                 if ($migration instanceof ConditionalMigration && ! $migration->shouldRun()) {
                     continue;
@@ -63,7 +59,12 @@ class MigrateCheckCommand extends BaseCommand
         });
     }
 
-    private function resolveMigration(string $path): object
+    private function migrator(): Migrator
+    {
+        return $this->laravel->make('migrator');
+    }
+
+    private function resolveMigration(Migrator $migrator, string $path): object
     {
         $migration = require $path;
 
@@ -71,14 +72,14 @@ class MigrateCheckCommand extends BaseCommand
             return $migration;
         }
 
-        return $this->migrator->resolve(
-            $this->migrator->getMigrationName($path),
+        return $migrator->resolve(
+            $migrator->getMigrationName($path),
         );
     }
 
     protected function getOptions(): array
     {
-        return [ // @phpstan-ignore return.type (matches Laravel convention for option definitions)
+        return [ // @phpstan-ignore return.type, missingType.iterableValue
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
             ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to use'],
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],

--- a/src/Database/MigrateCheckCommand.php
+++ b/src/Database/MigrateCheckCommand.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace MLL\LaravelUtils\Database;
+
+use Illuminate\Database\Console\Migrations\BaseCommand;
+use Illuminate\Database\Migrations\Migrator;
+use Symfony\Component\Console\Input\InputOption;
+
+class MigrateCheckCommand extends BaseCommand
+{
+    protected $name = 'migrate:check';
+
+    protected $description = 'Check if there are any pending migrations';
+
+    public function __construct(
+        protected Migrator $migrator
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        /** @var int Callback always returns int */
+        return $this->migrator->usingConnection($this->option('database'), function (): int { // @phpstan-ignore argument.type
+            if (! $this->migrator->repositoryExists()) {
+                $this->components->error('Migration table not found.');
+
+                return 1;
+            }
+
+            $files = $this->migrator->getMigrationFiles($this->getMigrationPaths());
+            $ran = $this->migrator->getRepository()->getRan();
+
+            $pendingFiles = array_diff_key($files, array_flip($ran));
+
+            $trulyPending = [];
+            foreach ($pendingFiles as $name => $path) {
+                $migration = $this->resolveMigration($path);
+
+                if ($migration instanceof ConditionalMigration && ! $migration->shouldRun()) {
+                    continue;
+                }
+
+                $trulyPending[] = $name;
+            }
+
+            if ($trulyPending === []) {
+                $this->components->info('No pending migrations');
+
+                return 0;
+            }
+
+            $this->components->error('Pending migrations');
+            $this->newLine();
+
+            foreach ($trulyPending as $name) {
+                $this->components->twoColumnDetail($name, '<fg=yellow;options=bold>Pending</>');
+            }
+
+            $this->newLine();
+
+            return 1;
+        });
+    }
+
+    private function resolveMigration(string $path): object
+    {
+        $migration = require $path;
+
+        if (is_object($migration)) {
+            return $migration;
+        }
+
+        return $this->migrator->resolve(
+            $this->migrator->getMigrationName($path),
+        );
+    }
+
+    protected function getOptions(): array
+    {
+        return [ // @phpstan-ignore return.type (matches Laravel convention for option definitions)
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
+            ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to use'],
+            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
+        ];
+    }
+}

--- a/src/Database/MigrateCheckCommand.php
+++ b/src/Database/MigrateCheckCommand.php
@@ -77,9 +77,9 @@ class MigrateCheckCommand extends BaseCommand
         );
     }
 
-    protected function getOptions(): array
+    protected function getOptions(): array // @phpstan-ignore missingType.iterableValue
     {
-        return [ // @phpstan-ignore return.type, missingType.iterableValue
+        return [ // @phpstan-ignore return.type
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
             ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to use'],
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],

--- a/tests/Database/MigrateCheckCommandTest.php
+++ b/tests/Database/MigrateCheckCommandTest.php
@@ -1,0 +1,212 @@
+<?php declare(strict_types=1);
+
+namespace MLL\LaravelUtils\Tests\Database;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Testing\PendingCommand;
+use MLL\LaravelUtils\Tests\DBTestCase;
+
+use function Safe\file_put_contents;
+use function Safe\glob;
+use function Safe\mkdir;
+use function Safe\rmdir;
+use function Safe\unlink;
+
+final class MigrateCheckCommandTest extends DBTestCase
+{
+    public function testExitsWithZeroWhenNoPendingMigrations(): void
+    {
+        $migrateFresh = $this->artisan('migrate:fresh', [
+            '--path' => __DIR__ . '/../../app/migrations',
+            '--realpath' => true,
+        ]);
+        self::assertInstanceOf(PendingCommand::class, $migrateFresh);
+        $migrateFresh->assertExitCode(0)->run();
+
+        $migrateCheck = $this->artisan('migrate:check', [
+            '--path' => __DIR__ . '/../../app/migrations',
+            '--realpath' => true,
+        ]);
+        self::assertInstanceOf(PendingCommand::class, $migrateCheck);
+        $migrateCheck->assertExitCode(0)
+            ->expectsOutputToContain('No pending migrations')
+            ->run();
+    }
+
+    public function testExitsWithOneWhenPendingNonConditionalMigration(): void
+    {
+        $path = $this->tempMigrationPath();
+        $this->createMigrationFile($path, '2099_01_01_000000_create_pending_table.php', <<<'PHP'
+            <?php declare(strict_types=1);
+
+            use Illuminate\Database\Migrations\Migration;
+
+            return new class() extends Migration {
+                public function up(): void {}
+            };
+            PHP);
+
+        try {
+            $migrateCheck = $this->artisan('migrate:check', [
+                '--path' => $path,
+                '--realpath' => true,
+            ]);
+            self::assertInstanceOf(PendingCommand::class, $migrateCheck);
+            $migrateCheck->assertExitCode(1)
+                ->expectsOutputToContain('2099_01_01_000000_create_pending_table')
+                ->run();
+        } finally {
+            $this->cleanupTempPath($path);
+        }
+    }
+
+    public function testExitsWithOneWhenPendingConditionalMigrationShouldRun(): void
+    {
+        $path = $this->tempMigrationPath();
+        $this->createMigrationFile($path, '2099_01_01_000000_create_conditional_should_run_table.php', <<<'PHP'
+            <?php declare(strict_types=1);
+
+            use Illuminate\Database\Migrations\Migration;
+            use MLL\LaravelUtils\Database\ConditionalMigration;
+
+            return new class() extends Migration implements ConditionalMigration {
+                public function up(): void {}
+
+                public function shouldRun(): bool
+                {
+                    return true;
+                }
+            };
+            PHP);
+
+        try {
+            $migrateCheck = $this->artisan('migrate:check', [
+                '--path' => $path,
+                '--realpath' => true,
+            ]);
+            self::assertInstanceOf(PendingCommand::class, $migrateCheck);
+            $migrateCheck->assertExitCode(1)
+                ->expectsOutputToContain('2099_01_01_000000_create_conditional_should_run_table')
+                ->run();
+        } finally {
+            $this->cleanupTempPath($path);
+        }
+    }
+
+    public function testFiltersConditionalMigrationThatShouldNotRun(): void
+    {
+        $path = $this->tempMigrationPath();
+        $this->createMigrationFile($path, '2099_01_01_000000_create_conditional_skip_table.php', <<<'PHP'
+            <?php declare(strict_types=1);
+
+            use Illuminate\Database\Migrations\Migration;
+            use MLL\LaravelUtils\Database\ConditionalMigration;
+
+            return new class() extends Migration implements ConditionalMigration {
+                public function up(): void {}
+
+                public function shouldRun(): bool
+                {
+                    return false;
+                }
+            };
+            PHP);
+
+        try {
+            $migrateCheck = $this->artisan('migrate:check', [
+                '--path' => $path,
+                '--realpath' => true,
+            ]);
+            self::assertInstanceOf(PendingCommand::class, $migrateCheck);
+            $migrateCheck->assertExitCode(0)
+                ->expectsOutputToContain('No pending migrations')
+                ->run();
+        } finally {
+            $this->cleanupTempPath($path);
+        }
+    }
+
+    public function testMixedPendingShowsOnlyTrulyPending(): void
+    {
+        $path = $this->tempMigrationPath();
+        $this->createMigrationFile($path, '2099_01_01_000000_create_mixed_skip_table.php', <<<'PHP'
+            <?php declare(strict_types=1);
+
+            use Illuminate\Database\Migrations\Migration;
+            use MLL\LaravelUtils\Database\ConditionalMigration;
+
+            return new class() extends Migration implements ConditionalMigration {
+                public function up(): void {}
+
+                public function shouldRun(): bool
+                {
+                    return false;
+                }
+            };
+            PHP);
+        $this->createMigrationFile($path, '2099_01_01_000001_create_mixed_pending_table.php', <<<'PHP'
+            <?php declare(strict_types=1);
+
+            use Illuminate\Database\Migrations\Migration;
+
+            return new class() extends Migration {
+                public function up(): void {}
+            };
+            PHP);
+
+        try {
+            $migrateCheck = $this->artisan('migrate:check', [
+                '--path' => $path,
+                '--realpath' => true,
+            ]);
+            self::assertInstanceOf(PendingCommand::class, $migrateCheck);
+            $migrateCheck->assertExitCode(1)
+                ->expectsOutputToContain('2099_01_01_000001_create_mixed_pending_table')
+                ->run();
+        } finally {
+            $this->cleanupTempPath($path);
+        }
+    }
+
+    public function testExitsWithOneWhenMigrationTableNotFound(): void
+    {
+        Schema::drop('migrations');
+
+        try {
+            $migrateCheck = $this->artisan('migrate:check', [
+                '--path' => __DIR__ . '/../../app/migrations',
+                '--realpath' => true,
+            ]);
+            self::assertInstanceOf(PendingCommand::class, $migrateCheck);
+            $migrateCheck->assertExitCode(1)
+                ->expectsOutputToContain('Migration table not found')
+                ->run();
+        } finally {
+            $migrateInstall = $this->artisan('migrate:install');
+            self::assertInstanceOf(PendingCommand::class, $migrateInstall);
+            $migrateInstall->run();
+        }
+    }
+
+    private function tempMigrationPath(): string
+    {
+        $path = __DIR__ . '/../../tmp-test-migrations-' . uniqid();
+        mkdir($path, 0777, true);
+
+        return $path;
+    }
+
+    private function createMigrationFile(string $path, string $filename, string $content): void
+    {
+        file_put_contents($path . '/' . $filename, $content);
+    }
+
+    private function cleanupTempPath(string $path): void
+    {
+        foreach (glob($path . '/*') as $file) {
+            assert(is_string($file));
+            unlink($file);
+        }
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
The erjanmx/laravel-migrate-check package is abandoned and unaware of
ConditionalMigration::shouldRun() — migrations skipped by
ConditionalMigrator are permanently reported as pending, breaking CI.

Since laravel-utils already owns ConditionalMigration + ConditionalMigrator,
the check command belongs here. It filters out conditional migrations where
shouldRun() returns false before reporting pending migrations.

🤖 Generated with Claude Code
