### PR TITLE
fix: migrate:check failing when no --path option is provided

### DIFF
--- a/src/Database/MigrateCheckCommand.php
+++ b/src/Database/MigrateCheckCommand.php
@@ -15,15 +15,9 @@ class MigrateCheckCommand extends BaseCommand
     /** @var Migrator */
     protected $migrator;
 
-    public function __construct(Migrator $migrator)
-    {
-        parent::__construct();
-
-        $this->migrator = $migrator;
-    }
-
     public function handle(): int
     {
+        $this->migrator = $this->laravel->make('migrator');
         $migrator = $this->migrator;
 
         /** @var int Callback always returns int */

--- a/src/Database/MigrateCheckCommand.php
+++ b/src/Database/MigrateCheckCommand.php
@@ -12,9 +12,19 @@ class MigrateCheckCommand extends BaseCommand
 
     protected $description = 'Check if there are any pending migrations';
 
+    /** @var Migrator */
+    protected $migrator;
+
+    public function __construct(Migrator $migrator)
+    {
+        parent::__construct();
+
+        $this->migrator = $migrator;
+    }
+
     public function handle(): int
     {
-        $migrator = $this->migrator();
+        $migrator = $this->migrator;
 
         /** @var int Callback always returns int */
         return $migrator->usingConnection($this->option('database'), function () use ($migrator): int { // @phpstan-ignore argument.type
@@ -57,11 +67,6 @@ class MigrateCheckCommand extends BaseCommand
 
             return 1;
         });
-    }
-
-    private function migrator(): Migrator
-    {
-        return $this->laravel->make('migrator');
     }
 
     private function resolveMigration(Migrator $migrator, string $path): object


### PR DESCRIPTION
`BaseCommand::getMigrationPaths()` accesses `$this->migrator->paths()` when no `--path` option is given. The previous implementation resolved the migrator lazily via a private method but never assigned it to `$this->migrator`, causing an "Undefined property" fatal error at runtime.

Declare `protected $migrator` and assign it at the start of `handle()` via `$this->laravel->make('migrator')`. Constructor injection is not viable because `MigrationRepositoryInterface` is not yet bound when the service provider registers the command.